### PR TITLE
Made gulp-rename and gulp-uglify dev-dependencies instead of regular dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,7 @@
         "url": "https://github.com/nikogu/amo/issues"
     },
     "devDependencies": {
-        "gulp": "^3.8.11"
-    },
-    "dependencies": {
+        "gulp": "^3.8.11",
         "gulp-rename": "^1.2.0",
         "gulp-uglify": "^1.1.0"
     },

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
         "url": "https://github.com/nikogu/amo/issues"
     },
     "devDependencies": {
-        "gulp": "^3.8.11",
-        "gulp-rename": "^1.2.0",
-        "gulp-uglify": "^1.1.0"
+        "gulp": "^3.9.1",
+        "gulp-rename": "^1.2.2",
+        "gulp-uglify": "^1.5.3"
     },
     "author": {
         "name": "niko",


### PR DESCRIPTION
#### ∩‿∩

This way, installing this library via npm does not cause that gulpiness to be installed as well.
